### PR TITLE
fix(qa): migrate from Ajv to Zod for schema validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "launch-test-system",
       "version": "0.1.0",
       "dependencies": {
-        "ajv": "^8.17.1",
-        "hono": "^4.4.0"
+        "hono": "^4.4.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240620.0",
@@ -2144,22 +2144,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2826,6 +2810,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -2871,22 +2856,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -3386,12 +3355,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -3615,6 +3578,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/minimatch": {
@@ -4051,15 +4024,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -5865,10 +5829,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
-      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
-      "dev": true,
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   ],
   "author": "",
   "dependencies": {
-    "ajv": "^8.17.1",
-    "hono": "^4.4.0"
+    "hono": "^4.4.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240620.0",

--- a/src/services/qa/schema-validator.ts
+++ b/src/services/qa/schema-validator.ts
@@ -1,152 +1,96 @@
 /**
- * ng_rules JSON Schema バリデーター
- * Ajvを使用してNG表現ルールの構造を検証
+ * ng_rules Zod スキーマバリデーター
+ * Zodを使用してNG表現ルールの構造を検証
+ *
+ * Note: AjvからZodへ移行（Cloudflare Workers互換性のため）
+ * Ajvはeval()を使用するためCloudflare Workersでは動作しない
  */
 
-import Ajv from 'ajv';
+import { z } from 'zod';
 import type { NgRules, SchemaValidationResult } from '../../types/qa.js';
 
 /**
- * ng_rules の JSON Schema 定義
+ * severity スキーマ（blocker または warning）
  */
-const ngRulesSchema = {
-  $schema: 'http://json-schema.org/draft-07/schema#',
-  type: 'object',
-  required: [
-    'version',
-    'blocked_terms',
-    'blocked_patterns',
-    'allowlist_terms',
-    'required_disclaimer',
-    'claim_requires_evidence',
-    'normalization',
-  ],
-  properties: {
-    version: {
-      type: 'string',
-      description: 'ルールバージョン',
-    },
-    blocked_terms: {
-      type: 'array',
-      items: { type: 'string' },
-      description: '禁止用語リスト',
-    },
-    blocked_patterns: {
-      type: 'array',
-      items: {
-        type: 'object',
-        required: ['pattern', 'reason', 'severity'],
-        properties: {
-          pattern: {
-            type: 'string',
-            description: '正規表現パターン',
-          },
-          flags: {
-            type: 'string',
-            description: '正規表現フラグ（例: "gi"）',
-          },
-          reason: {
-            type: 'string',
-            description: 'ブロック理由',
-          },
-          severity: {
-            type: 'string',
-            enum: ['blocker', 'warning'],
-            description: '重要度',
-          },
-        },
-        additionalProperties: false,
-      },
-      description: '禁止パターンリスト',
-    },
-    allowlist_terms: {
-      type: 'array',
-      items: { type: 'string' },
-      description: '許可リスト',
-    },
-    required_disclaimer: {
-      type: 'array',
-      items: { type: 'string' },
-      description: '必須免責事項リスト',
-    },
-    claim_requires_evidence: {
-      type: 'array',
-      items: {
-        type: 'object',
-        required: ['pattern', 'evidence_types', 'severity'],
-        properties: {
-          pattern: {
-            type: 'string',
-            description: '主張を検出する正規表現パターン',
-          },
-          evidence_types: {
-            type: 'array',
-            items: { type: 'string' },
-            description: '許可されるエビデンスの種類',
-          },
-          severity: {
-            type: 'string',
-            enum: ['blocker', 'warning'],
-            description: '重要度',
-          },
-        },
-        additionalProperties: false,
-      },
-      description: '主張に対するエビデンス要求ルール',
-    },
-    normalization: {
-      type: 'object',
-      required: ['ignore_whitespace', 'ignore_punctuation', 'case_insensitive'],
-      properties: {
-        ignore_whitespace: {
-          type: 'boolean',
-          description: '空白を無視するか',
-        },
-        ignore_punctuation: {
-          type: 'boolean',
-          description: '句読点を無視するか',
-        },
-        case_insensitive: {
-          type: 'boolean',
-          description: '大文字小文字を区別しないか',
-        },
-      },
-      additionalProperties: false,
-      description: 'テキスト正規化オプション',
-    },
-  },
-  additionalProperties: false,
-};
+const severitySchema = z.enum(['blocker', 'warning']);
+
+/**
+ * blocked_patterns 項目のスキーマ
+ */
+const blockedPatternSchema = z
+  .object({
+    pattern: z.string().describe('正規表現パターン'),
+    flags: z.string().optional().describe('正規表現フラグ（例: "gi"）'),
+    reason: z.string().describe('ブロック理由'),
+    severity: severitySchema.describe('重要度'),
+  })
+  .strict();
+
+/**
+ * claim_requires_evidence 項目のスキーマ
+ */
+const claimRequiresEvidenceSchema = z
+  .object({
+    pattern: z.string().describe('主張を検出する正規表現パターン'),
+    evidence_types: z.array(z.string()).describe('許可されるエビデンスの種類'),
+    severity: severitySchema.describe('重要度'),
+  })
+  .strict();
+
+/**
+ * normalization オプションのスキーマ
+ */
+const normalizationSchema = z
+  .object({
+    ignore_whitespace: z.boolean().describe('空白を無視するか'),
+    ignore_punctuation: z.boolean().describe('句読点を無視するか'),
+    case_insensitive: z.boolean().describe('大文字小文字を区別しないか'),
+  })
+  .strict();
+
+/**
+ * ng_rules の Zod スキーマ定義
+ */
+export const ngRulesZodSchema = z
+  .object({
+    version: z.string().describe('ルールバージョン'),
+    blocked_terms: z.array(z.string()).describe('禁止用語リスト'),
+    blocked_patterns: z.array(blockedPatternSchema).describe('禁止パターンリスト'),
+    allowlist_terms: z.array(z.string()).describe('許可リスト'),
+    required_disclaimer: z.array(z.string()).describe('必須免責事項リスト'),
+    claim_requires_evidence: z
+      .array(claimRequiresEvidenceSchema)
+      .describe('主張に対するエビデンス要求ルール'),
+    normalization: normalizationSchema.describe('テキスト正規化オプション'),
+  })
+  .strict();
+
+/**
+ * Zodスキーマから推論される型
+ */
+export type NgRulesFromSchema = z.infer<typeof ngRulesZodSchema>;
 
 /**
  * NgRulesスキーマバリデーター
+ * Zodを使用してCloudflare Workers互換のバリデーションを提供
  */
 export class NgRulesSchemaValidator {
-  private ajv: Ajv;
-  private validateFn: ReturnType<Ajv['compile']>;
-
-  constructor() {
-    this.ajv = new Ajv({ allErrors: true });
-    this.validateFn = this.ajv.compile(ngRulesSchema);
-  }
-
   /**
    * ng_rules オブジェクトをスキーマに対して検証
    * @param data 検証対象のデータ
    * @returns 検証結果
    */
   validate(data: unknown): SchemaValidationResult {
-    const valid = this.validateFn(data);
+    const result = ngRulesZodSchema.safeParse(data);
 
-    if (valid) {
+    if (result.success) {
       return { valid: true };
     }
 
-    const errors =
-      this.validateFn.errors?.map((err) => {
-        const path = err.instancePath || '/';
-        return `${path}: ${err.message}`;
-      }) ?? [];
+    const errors = result.error.errors.map((err) => {
+      const path = err.path.length > 0 ? `/${err.path.join('/')}` : '/';
+      return `${path}: ${err.message}`;
+    });
 
     return { valid: false, errors };
   }
@@ -176,9 +120,118 @@ export class NgRulesSchemaValidator {
 export const ngRulesValidator = new NgRulesSchemaValidator();
 
 /**
- * ng_rules スキーマを取得
- * @returns JSON Schema定義
+ * ng_rules スキーマを取得（JSON Schema形式に変換）
+ * @returns JSON Schema風の定義オブジェクト
  */
 export function getNgRulesSchema(): object {
-  return { ...ngRulesSchema };
+  // Zodスキーマの構造を反映したJSON Schema風のオブジェクトを返す
+  // 後方互換性のため、元のJSON Schema形式を維持
+  return {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    type: 'object',
+    required: [
+      'version',
+      'blocked_terms',
+      'blocked_patterns',
+      'allowlist_terms',
+      'required_disclaimer',
+      'claim_requires_evidence',
+      'normalization',
+    ],
+    properties: {
+      version: {
+        type: 'string',
+        description: 'ルールバージョン',
+      },
+      blocked_terms: {
+        type: 'array',
+        items: { type: 'string' },
+        description: '禁止用語リスト',
+      },
+      blocked_patterns: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['pattern', 'reason', 'severity'],
+          properties: {
+            pattern: {
+              type: 'string',
+              description: '正規表現パターン',
+            },
+            flags: {
+              type: 'string',
+              description: '正規表現フラグ（例: "gi"）',
+            },
+            reason: {
+              type: 'string',
+              description: 'ブロック理由',
+            },
+            severity: {
+              type: 'string',
+              enum: ['blocker', 'warning'],
+              description: '重要度',
+            },
+          },
+          additionalProperties: false,
+        },
+        description: '禁止パターンリスト',
+      },
+      allowlist_terms: {
+        type: 'array',
+        items: { type: 'string' },
+        description: '許可リスト',
+      },
+      required_disclaimer: {
+        type: 'array',
+        items: { type: 'string' },
+        description: '必須免責事項リスト',
+      },
+      claim_requires_evidence: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['pattern', 'evidence_types', 'severity'],
+          properties: {
+            pattern: {
+              type: 'string',
+              description: '主張を検出する正規表現パターン',
+            },
+            evidence_types: {
+              type: 'array',
+              items: { type: 'string' },
+              description: '許可されるエビデンスの種類',
+            },
+            severity: {
+              type: 'string',
+              enum: ['blocker', 'warning'],
+              description: '重要度',
+            },
+          },
+          additionalProperties: false,
+        },
+        description: '主張に対するエビデンス要求ルール',
+      },
+      normalization: {
+        type: 'object',
+        required: ['ignore_whitespace', 'ignore_punctuation', 'case_insensitive'],
+        properties: {
+          ignore_whitespace: {
+            type: 'boolean',
+            description: '空白を無視するか',
+          },
+          ignore_punctuation: {
+            type: 'boolean',
+            description: '句読点を無視するか',
+          },
+          case_insensitive: {
+            type: 'boolean',
+            description: '大文字小文字を区別しないか',
+          },
+        },
+        additionalProperties: false,
+        description: 'テキスト正規化オプション',
+      },
+    },
+    additionalProperties: false,
+  };
 }


### PR DESCRIPTION
## Summary
- AjvからZodへスキーマバリデーションを移行
- Cloudflare Workersの動的コード生成（eval）制限に対応
- 後方互換性を維持したJSON Schema形式の出力をサポート

## Test plan
- [x] TypeScriptコンパイル成功（0 errors）
- [x] ESLint通過（0 errors）
- [x] 全テスト通過（17 tests passed）
- [x] セキュリティスキャン通過（0 vulnerabilities）

## Quality Report
```
Quality Score: 100/100
TypeScript: 0 errors
ESLint: 0 errors
Tests: 17 passed
Security: 0 vulnerabilities
```

## Changes
- `src/services/qa/schema-validator.ts` - AjvからZodへの移行
- `package.json` - ajv削除、zod追加
- `package-lock.json` - 依存関係更新

Closes #41

---

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>